### PR TITLE
Add OBS Websocket advanced module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -4,6 +4,7 @@
     "https://raw.githubusercontent.com/jonglissimo/Light-Control-Chataigne-Module/master/module.json",
     "https://raw.githubusercontent.com/yastefan/grandMA3-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/benkuper/EOS-OSC-Chataigne-Module/master/module.json",
+    "https://raw.githubusercontent.com/KopiasCsaba/Chataigne-Module-OBS-Websocket-Advanced/main/module.json",
     "https://raw.githubusercontent.com/Edrig/OBS-Websocket-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/Guesn/Voicemeeter-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/DrMicka/TwitchChat-ChataigneModule/main/module.json",


### PR DESCRIPTION
I have just rewritten almost from scratch the original OBS module, the purpose was to be more programatical about the protocol: to avoid manual labour, and manual methods on everything, stuff are generalized to parse the original API definition and transform it into Chataigne's world. The module.json's templates are generated based on the protocol definition as well.

My hope is that it is more robust this way, and easier to maintain as well. If the API changes it just needs to be regenerated.

I was also missing some features, and fixed some bugs in the previous version as well. For example i have opened a PR for the event subscription fix into the original, and of course this one contains that as well.

Cheers!