### PR TITLE
Add ETC Smartfade ML module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -75,6 +75,7 @@
     "https://raw.githubusercontent.com/zak-45/SCAnalyzer-Chataigne-Module/refs/heads/main/module.json",
     "https://raw.githubusercontent.com/zak-45/SpleeterGUI-Chataigne-Module/refs/heads/main/module.json",
     "https://raw.githubusercontent.com/norbertrostaing/dmxSequencePlayerChataigne/main/module.json",
-    "https://raw.githubusercontent.com/eLandon/Chataigne_ScriptObjectExplorer/refs/heads/master/module.json"
+    "https://raw.githubusercontent.com/eLandon/Chataigne_ScriptObjectExplorer/refs/heads/master/module.json",
+    "https://raw.githubusercontent.com/tobyroworth/ETC-Smartfade-ML_Chataigne/refs/heads/main/module.json"
   ]
 }


### PR DESCRIPTION
Simple module for controlling an ETC Smartfade ML over MIDI.

[tobyroworth/ETC-Smartfade-ML_Chataigne
](https://github.com/tobyroworth/ETC-Smartfade-ML_Chataigne)