### PR TITLE
Update modules.json to add RLY88 custom module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -77,6 +77,7 @@
     "https://raw.githubusercontent.com/norbertrostaing/dmxSequencePlayerChataigne/main/module.json",
     "https://raw.githubusercontent.com/eLandon/Chataigne_ScriptObjectExplorer/refs/heads/master/module.json",
     "https://raw.githubusercontent.com/tobyroworth/ETC-Smartfade-ML_Chataigne/refs/heads/main/module.json",
-    "https://raw.githubusercontent.com/pierrelemmel/chataigne-openpose/master/module/module.json"
+    "https://raw.githubusercontent.com/pierrelemmel/chataigne-openpose/master/module/module.json",
+    "https://raw.githubusercontent.com/gniluje/RLY88-Chataigne-Module/refs/heads/main/module.json"
   ]
 }


### PR DESCRIPTION
Add a hardware custom module to interface in an easier way RLY88 board from Robot Electronics with Chataigne.
Check : https://www.robot-electronics.co.uk/htm/usb_opto_rly88tech.htm