### PR TITLE
Adding TXL Timecode Expert 2 Chataigne Module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -38,6 +38,7 @@
     "https://raw.githubusercontent.com/ziginfo/LogicPro-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/ziginfo/Live-OSC-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/ssm2017/MidiMSC-Chataigne-module/master/module.json",
+    "https://raw.githubusercontent.com/jimdelois/Timecode-Expert-2-Chataigne-Module/refs/heads/main/module.json",
     "https://raw.githubusercontent.com/niklasberlin/Midicraft-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/zak-45/WLED-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/norbertrostaing/LeapMotionForChataigne/main/module.json",


### PR DESCRIPTION
Adding "Timecode Expert 2" Chataigne Module - https://github.com/jimdelois/Timecode-Expert-2-Chataigne-Module