### PR TITLE
add grandMA2 module.

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -3,6 +3,7 @@
     "https://raw.githubusercontent.com/benkuper/VLC-Chataigne-Module/master/module.json",
     "https://raw.githubusercontent.com/jonglissimo/Light-Control-Chataigne-Module/master/module.json",
     "https://raw.githubusercontent.com/yastefan/grandMA3-Chataigne-Module/main/module.json",
+    "https://raw.githubusercontent.com/DJFPaul/grandMA2-Chataigne-Module/main/module.json",
     "https://raw.githubusercontent.com/benkuper/EOS-OSC-Chataigne-Module/master/module.json",
     "https://raw.githubusercontent.com/benkuper/MagicQ-Chataigne-Module/refs/heads/main/module.json",
     "https://raw.githubusercontent.com/KopiasCsaba/Chataigne-Module-OBS-Websocket-Advanced/main/module.json",


### PR DESCRIPTION
This change adds my just published grandMA2 module to the list.
I've placed it below grandMA3 for better finding and to not segment the list even more.